### PR TITLE
[FIX] remove references to 'self' keyword in imports

### DIFF
--- a/gg2/models/models.py
+++ b/gg2/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 # TO DO: Make database name always appear in the top banner by changing the Java Script
 # /odoo/odoo-server/addons/web/static/src/js/chrome/user_menu.js

--- a/gg2_account/models/models.py
+++ b/gg2_account/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class TsaAccountInvoice(models.Model):
     _inherit = ['account.move']

--- a/gg2_attendance/models/models.py
+++ b/gg2_attendance/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaexte(models.Model):
     _inherit = ['hr.attendance']

--- a/gg2_contacts/models/models.py
+++ b/gg2_contacts/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaexto(models.Model):
     _inherit = ['res.partner']

--- a/gg2_inventory/models/models.py
+++ b/gg2_inventory/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaextt(models.Model):
     _inherit = ['stock.picking']

--- a/gg2_manufacture/models/models.py
+++ b/gg2_manufacture/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaextf(models.Model):
     _inherit = ['mrp.bom.line']

--- a/gg2_product/models/models.py
+++ b/gg2_product/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaexth(models.Model):
     _inherit = ['product.category']

--- a/gg2_purchase/models/models.py
+++ b/gg2_purchase/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaextl(models.Model):
     _inherit = ['purchase.order']

--- a/gg2_repair/models/models.py
+++ b/gg2_repair/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class tsaextg(models.Model):
     _inherit = ['repair.order']

--- a/gg2_reports/models/models.py
+++ b/gg2_reports/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class TsaRpt050BankJouA(models.Model):
     _name = "gg2_reports.bankjou"

--- a/gg2_sale/models/models.py
+++ b/gg2_sale/models/models.py
@@ -4,7 +4,7 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self
 
 class TsaSaleOrder(models.Model):
     _inherit = ['sale.order']

--- a/gg2_website/models/models.py
+++ b/gg2_website/models/models.py
@@ -4,4 +4,4 @@ from typing import Any, Union
 from odoo import models, fields, api, tools, _
 from odoo.exceptions import UserError
 import pdb
-from mock.mock import self
+# from mock.mock import self


### PR DESCRIPTION
After recent database update to Ubuntu 20, these imports create an error when launching the database.
This commit will comment out all references to this keyword

task-4393737
pca-Odoo